### PR TITLE
Add simple GUI validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <module>library</module>
         <module>validator</module>
         <module>Mustang-CLI</module>
+        <module>validator-gui</module>
     </modules>
 
     <description>Mustangproject is a java library and commandline tool to read, validate, write and convert EN16931 e-invoices, e.g. Factur-X and XRechnung (read and writing CII and reading also UBL).

--- a/validator-gui/pom.xml
+++ b/validator-gui/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.mustangproject</groupId>
+        <artifactId>core</artifactId>
+        <version>2.17.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mustangproject</groupId>
+    <artifactId>validator-gui</artifactId>
+    <name>E-Rechnungsvalidator GUI</name>
+    <packaging>jar</packaging>
+    <version>2.17.1-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.mustangproject</groupId>
+            <artifactId>validator</artifactId>
+            <version>2.17.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.16</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.mustangproject.gui.ValidatorGUI</mainClass>
+                        </transformer>
+                    </transformers>
+                    <minimizeJar>false</minimizeJar>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/validator-gui/src/main/java/org/mustangproject/gui/ValidatorGUI.java
+++ b/validator-gui/src/main/java/org/mustangproject/gui/ValidatorGUI.java
@@ -1,0 +1,59 @@
+package org.mustangproject.gui;
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.io.File;
+
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
+import org.mustangproject.validator.ZUGFeRDValidator;
+
+/**
+ * Einfache grafische Oberfläche zum Validieren von ZUGFeRD/Factur-X Dateien.
+ */
+public class ValidatorGUI extends JFrame {
+    private final JTextArea outputArea = new JTextArea();
+
+    public ValidatorGUI() {
+        super("ZUGFeRD Validator");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setLayout(new BorderLayout());
+
+        JButton openButton = new JButton("Datei wählen...");
+        openButton.addActionListener(this::chooseFile);
+        add(openButton, BorderLayout.NORTH);
+
+        outputArea.setEditable(false);
+        add(new JScrollPane(outputArea), BorderLayout.CENTER);
+
+        setSize(600, 400);
+        setLocationRelativeTo(null);
+    }
+
+    private void chooseFile(ActionEvent e) {
+        JFileChooser chooser = new JFileChooser();
+        if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            validateFile(file);
+        }
+    }
+
+    private void validateFile(File file) {
+        outputArea.setText("Validiere " + file.getName() + "...\n");
+        ZUGFeRDValidator validator = new ZUGFeRDValidator();
+        String result = validator.validate(file.getAbsolutePath());
+        outputArea.append(result);
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            ValidatorGUI gui = new ValidatorGUI();
+            gui.setVisible(true);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add new `validator-gui` module providing a Swing front‑end
- list the new module in the main pom
- implement `ValidatorGUI` with a file chooser and XML result viewer

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867a2be3d288332b153d49477df7392